### PR TITLE
fix broken link in sharing a cluster page

### DIFF
--- a/mirrord.dev/content/docs/using-mirrord/sharing-the-cluster/index.md
+++ b/mirrord.dev/content/docs/using-mirrord/sharing-the-cluster/index.md
@@ -28,7 +28,7 @@ These conflicts and more are resolved by the mirrord Operator, available in the 
 {{<figure src="images/shared-cluster.png" alt="Using clusters concurrently with mirrord" class="w-4/5 margin-auto zoomable">}}
 
 ### 1. Concurrently debug the same HTTP server with HTTP filters
-mirrord's HTTP filters let users only steal a subset of the incoming traffic to the remote service. By adding personalized headers to incoming traffic and then configuring mirrord to only steal traffic with those headers, users can debug the same service concurrently without affecting each other. [Learn more about HTTP filters](/docs/using-mirrord/http-filters/).
+mirrord's HTTP filters let users only steal a subset of the incoming traffic to the remote service. By adding personalized headers to incoming traffic and then configuring mirrord to only steal traffic with those headers, users can debug the same service concurrently without affecting each other. [Learn more about HTTP filters](/docs/using-mirrord/steal/#stealing-only-a-subset-of-the-remote-targets-traffic).
 > **_NOTE:_**  While HTTP filters are supported in the OSS version of mirrord, concurrently debugging the same service using HTTP filters is only supported in the Team and Enterprise versions.
 
 


### PR DESCRIPTION
Broken link in docs. In [this para](https://metalbear.co/mirrord/docs/using-mirrord/sharing-the-cluster/#1-concurrently-debug-the-same-http-server-with-http-filters) the link to [HTTP filters page](https://metalbear.co/docs/using-mirrord/http-filters/) is broken. It should be pointing to this now: https://metalbear.co/mirrord/docs/using-mirrord/steal/#stealing-only-a-subset-of-the-remote-targets-traffic