### PR TITLE
fix captions and update top devx tools blog

### DIFF
--- a/assets/scss/components/_images.scss
+++ b/assets/scss/components/_images.scss
@@ -4,6 +4,20 @@ figure {
 
 .figure-caption {
   margin: 0.25rem 0 0.75rem;
+  text-align: center;
+  max-width: 80%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+figcaption h4 {
+  font-size: 0.85rem !important;
+  font-style: italic !important;
+  color: #777 !important;
+  line-height: 1.2 !important;
+  font-weight: 400 !important;
+  margin: 0 !important;
+  padding: 0 !important;
 }
 
 figcaption {

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -1,0 +1,41 @@
+/* Custom overrides for MetalBear website */
+
+/* Enhanced figure caption styling - targeting Hugo's figure-caption class */
+.figure-caption {
+  font-size: 0.75rem !important;
+  font-style: italic !important;
+  color: #777 !important;
+  line-height: 1.2 !important;
+  font-weight: 400 !important;
+  margin-top: 1em !important;
+  margin-bottom: 1.5em !important;
+  text-align: center !important;
+  max-width: 80% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  padding: 0 !important;
+}
+
+/* Target any paragraph inside figure-caption */
+.figure-caption p {
+  font-size: 0.75rem !important;
+  font-style: italic !important;
+  color: #777 !important;
+  line-height: 1.2 !important;
+  font-weight: 400 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+/* Wide figure captions */
+figure.wide .figure-caption {
+  max-width: calc(100% - 3rem) !important;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .figure-caption {
+    max-width: 90% !important;
+    font-size: 0.7rem !important;
+  }
+}

--- a/content/en/blog/top-pick-devx-tools/index.md
+++ b/content/en/blog/top-pick-devx-tools/index.md
@@ -70,7 +70,7 @@ The most significant delays often come from misalignment, not bad code. These to
 {{<
 figure src="vcluster.png" class="no-resize"
 alt="vCluster Introduction"
-caption="vCluster spins up isolated Kubernetes control planes inside namespaces, enabling fast, conflict-free team environments."
+title="vCluster spins up isolated Kubernetes control planes inside namespaces, enabling fast, conflict-free team environments."
 >}}
 
 vCluster creates virtual clusters that are fully functional Kubernetes control planes running inside namespace-scoped pods in a host cluster. This enables powerful collaboration patterns that were previously impossible.
@@ -101,7 +101,7 @@ vCluster works well for collaborative Kubernetes development at scale. For a mor
 {{<
 figure src="devcontainers.png" class="no-resize"
 alt="Devcontainers Introduction"
-caption="Devcontainers standardize development environments using containerized toolchains and editor integration like VS Code."
+title="Devcontainers standardize development environments using containerized toolchains and editor integration like VS Code."
 >}}
 
 
@@ -151,7 +151,7 @@ Tools in this category help you connect your code to live infrastructure from yo
 {{<
 figure src="mirrord-remocal.png" class="no-resize"
 alt="Remocal Introduction"
-caption="mirrord connects your local process to a live Kubernetes pod for real-time debugging without redeploying."
+title="mirrord connects your local process to a live Kubernetes pod for real-time debugging without redeploying."
 >}}
 
 
@@ -184,7 +184,7 @@ If your team is building for Kubernetes and you want to adopt remocal developmen
 {{<
 figure src="tilt.png" class="no-resize"
 alt="Tilt Introduction"
-caption="Tilt automates rebuild and redeploy cycles with a unified dashboard for monitoring all services during development."
+title="Tilt automates rebuild and redeploy cycles with a unified dashboard for monitoring all services during development."
 >}}
 
 Tilt is a solid choice if you want to automate build, deployment, and live-update cycles for your local K8s development. Tilt is not constrained to Kubernetes only and can be used in many things related to microservice development. It helps to solve one of the main struggles of dev teams: the constant rebuild-deploy-test cycle that slows delivery.
@@ -231,7 +231,7 @@ Inconsistent setups and config drift create bugs that only show up after deploym
 {{<
 figure src="crossplane.png" class="no-resize"
 alt="Crossplane Introduction"
-caption="Crossplane provisions cloud resources across providers using Kubernetes-native infrastructure as code."
+title="Crossplane provisions cloud resources across providers using Kubernetes-native infrastructure as code."
 >}}
 
 
@@ -264,7 +264,7 @@ Now let's look at KubeVela, which brings a platform-agnostic approach to applica
 {{<
 figure src="kubevela.png" class="no-resize"
 alt="KubeVela Introduction"
-caption="KubeVela enables platform-agnostic application delivery through reusable, declarative deployment patterns."
+title="KubeVela enables platform-agnostic application delivery through reusable, declarative deployment patterns."
 >}}
 
 KubeVela is a CNCF project that focuses on making application delivery consistent and extensible across different environments. It provides an application-centric delivery platform that separates application definition from deployment.

--- a/static/css/custom-caption.css
+++ b/static/css/custom-caption.css
@@ -1,0 +1,33 @@
+/* Custom styling for figure captions - loaded after all other styles */
+.figure-caption {
+  font-size: 0.75rem !important;
+  font-style: italic !important;
+  color: #777 !important;
+  line-height: 1.2 !important;
+  font-weight: 400 !important;
+  margin-top: 1em !important;
+  margin-bottom: 1.5em !important;
+  text-align: center !important;
+  max-width: 80% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  padding: 0 !important;
+}
+
+/* For paragraphs inside captions */
+.figure-caption p {
+  font-size: inherit !important;
+  font-style: inherit !important;
+  color: inherit !important;
+  line-height: inherit !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+/* Media query for smaller screens */
+@media (max-width: 768px) {
+  .figure-caption {
+    font-size: 0.7rem !important;
+    max-width: 90% !important;
+  }
+}


### PR DESCRIPTION
Hugo wraps the caption text in `<h4>` tags inside the `<figcaption>` element. Our CSS was targeting `.figure-caption` and `figcaption p`, but not the `h4` elements that were actually being rendered.

1. Updated the CSS in `_images.scss` to specifically target `figcaption h4` elements with the desired styling (0.85rem font size, italic style, #777 color)
2. Changed figure shortcode usage in blog posts from `caption` parameter to `title` parameter
3. Included additional custom CSS files as backup to ensure styles are properly applied
